### PR TITLE
[minor] Generator.jl -> generator.jl

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -17,10 +17,10 @@ a C++20 compliant compiler.
 ## Usage
 
 Once Julia is installed, you can generate test data for a particular problem
-with the `src/Generator/Generator.jl` script:
+with the `src/Generator/generator.jl` script:
 
 ```bash
-% julia src/Generator/Generator.jl --help
+% julia src/Generator/generator.jl --help
 ```
 
 The script will generate a dataset for a particular problem and write it to
@@ -29,7 +29,7 @@ the given destination.
 For example, to generate RMAT data for spmv in the default location under
 `./data/` run the following command: 
 ```bash
-% julia src/Generator/Generator.jl spmv RMAT
+% julia src/Generator/generator.jl spmv RMAT
 ```
 
 Implementations of a given kernel are expected to be given as executables that


### PR DESCRIPTION
Small change to make the README quick start commands correct. 

(For the record, this PR is not for the application, just something small I noticed during set up.)
